### PR TITLE
Update php.ini

### DIFF
--- a/php.ini
+++ b/php.ini
@@ -3,7 +3,7 @@
 ;
 ; Increase PHP memory limit
 ;
-memory_limit = 512M
+memory_limit = 1G
 
 ;
 ; enable resulting html compression
@@ -24,3 +24,8 @@ realpath_cache_ttl = 7200
 ; Multi store support
 ;
 auto_prepend_file = /app/public/magento-vars.php
+
+:
+; This feature was DEPRECATED in PHP 5.6.0, and REMOVED as of PHP 7.0.0.
+:
+always_populate_raw_post_data = -1


### PR DESCRIPTION
- increase memory_limit up to 1 GB. Magento recommendation is minimum 768 MB for production and 2 GB for development. 768 MB may be not enough when you switch application modes
- define always_populate_raw_post_data = -1. This feature was DEPRECATED in PHP 5.6.0, and REMOVED as of PHP 7.0.0.
