### PR TITLE
Fix category-ids patches to be applicable to Magento 2.0.5+

### DIFF
--- a/patches/install-category-ids-1.patch
+++ b/patches/install-category-ids-1.patch
@@ -1,5 +1,5 @@
 diff --git a/Setup/InstallData.php b/Setup/InstallData.php
-index bff2d66..0289fee 100644
+index 9b2139d..0289fee 100644
 --- a/Setup/InstallData.php
 +++ b/Setup/InstallData.php
 @@ -23,6 +23,20 @@ class InstallData implements InstallDataInterface
@@ -32,31 +32,22 @@ index bff2d66..0289fee 100644
 +            ->load($this->rootCategoryId)
 +            ->setId($this->rootCategoryId)
              ->setStoreId(0)
--            ->setPath('1')
+-            ->setPath(1)
 +            ->setPath($this->rootCategoryId)
              ->setLevel(0)
              ->setPosition(0)
              ->setChildrenCount(0)
-@@ -57,17 +71,18 @@ class InstallData implements InstallDataInterface
-             ->setInitialSetupFlag(true)
-             ->save();
+@@ -59,10 +73,10 @@ class InstallData implements InstallDataInterface
  
-+        // Create Default Catalog Node
+         // Create Default Catalog Node
          $category = $categorySetup->createCategory();
--
--        $categorySetup->createCategory()
+-        $category->load(2)
+-            ->setId(2)
 +        $category->load(self::DEFAULT_CATEGORY_ID)
 +            ->setId(self::DEFAULT_CATEGORY_ID)
              ->setStoreId(0)
--            ->setPath('1')
+-            ->setPath('1/2')
 +            ->setPath($this->rootCategoryId . '/' . self::DEFAULT_CATEGORY_ID)
              ->setName('Default Category')
              ->setDisplayMode('PRODUCTS')
--            ->setAttributeSetId($category->getDefaultAttributeSetId())
              ->setIsActive(1)
-             ->setLevel(1)
-             ->setInitialSetupFlag(true)
-+            ->setAttributeSetId($category->getDefaultAttributeSetId())
-             ->save();
- 
-         $data = [

--- a/patches/install-category-ids-2.patch
+++ b/patches/install-category-ids-2.patch
@@ -1,16 +1,8 @@
 diff --git a/Setup/InstallSchema.php b/Setup/InstallSchema.php
-index cc81a6f..5f0031e 100644
+index 241028a..5f0031e 100644
 --- a/Setup/InstallSchema.php
 +++ b/Setup/InstallSchema.php
-@@ -10,6 +10,7 @@ use Magento\Framework\Setup\InstallSchemaInterface;
- use Magento\Framework\Setup\ModuleContextInterface;
- use Magento\Framework\Setup\SchemaSetupInterface;
- use \Magento\Framework\DB\Ddl\Table;
-+use \Magento\Catalog\Setup\InstallData;
- 
- /**
-  * @codeCoverageIgnore
-@@ -259,7 +260,7 @@ class InstallSchema implements InstallSchemaInterface
+@@ -260,7 +260,7 @@ class InstallSchema implements InstallSchemaInterface
                  'group_id' => 1,
                  'website_id' => 1,
                  'name' => 'Main Website Store',


### PR DESCRIPTION
The category ID patches did not work on the current Magento2 version (2.0.6). This is because the patches were based on Magento 2.0.4 and things have changed between 2.0.4 and 2.0.5:

![platformsh-example-magento-patches-issue](https://cloud.githubusercontent.com/assets/2794908/17217883/40518b60-54e6-11e6-9da1-c6121ef2e8d5.png)

After I fixed these patches, the [cweagans/composer-patches](https://github.com/cweagans/composer-patches) package will apply the patches correctly again (on 2.0.5, 2.0.6 and this was actually on a 2.0.7 setup):

![platformsh-example-magento-patches-issue-solved](https://cloud.githubusercontent.com/assets/2794908/17217941/62b4cfb4-54e6-11e6-8ceb-4e8a4ae1bd68.png)
