### PR TITLE
added support for static asset file signing in magento

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -55,6 +55,9 @@ web:
             allow: true
             scripts: false
             passthru: "/front-static.php"
+            rules:
+                ^/static/version\d+/(?<resource>.*)$:
+                    passthru: "/static/$resource"
 
 
 # The size of the persistent disk of the application (in MB).


### PR DESCRIPTION
The sample application.yaml file was not serving static assets correctly when Magento's static asset file signing option was enabled. This fixes that issue. 